### PR TITLE
Correctly use of CPU in ttsmodel

### DIFF
--- a/dimits/ttsmodel.py
+++ b/dimits/ttsmodel.py
@@ -84,7 +84,7 @@ class TextToSpeechModel:
       
         self.phonemizer = Phonemizer(self.config.espeak.voice)
         self.model = ort.InferenceSession(str(model_path),sess_options=ort.SessionOptions(),
-            providers= ["CPUExecutionProvider"] if(use_cpu == False) else ['CUDAExecutionProvider']
+            providers= ["CPUExecutionProvider"] if(use_cpu == True) else ['CUDAExecutionProvider']
            )
 
     def synthesize(


### PR DESCRIPTION
The logic of using the CPU provider was wrong. Instead of using the CPU provider if the "use_cpu" variable was True, it was using it when it was False.